### PR TITLE
signal echo back issues are fixed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,4 +58,4 @@ re:			fclean all
 
 -include $(DEPS)
 
-.PHONY:     all clean fclean re
+.PHONY:     all clean fclean re set_inputrc


### PR DESCRIPTION
参考:https://wiki.archlinux.jp/index.php/Readline
8. 制御エコーを無効にする